### PR TITLE
Added a 'See personalised recommendations' block between the home page and footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,6 @@
 <body>
 
     <div id="navbar">
-        <!-- Make the amazon logo clickable which will bring the user to index.html -->
         <a href="/index.html">
             <img class="amazon-logo" src="./amazon assets/logo.webp">
         </a>
@@ -302,13 +301,18 @@
             <a href="#" class="see-more">See More</a>
         </div>
     </div>
-    <hr>
+
+    <div class="personalised-recommendations">
+        <hr>
+        <h2>See personalised recommendations</h2>
+        <button class="sign-in-button" onclick="window.location.href='Loginpage.html'">Sign in</button>
+        <p>New customer? <a href="Signuppage.html" class="start-here-link">Start here.</a></p>
+        <hr>
+    </div>
 
     <div class="backtotop">
         Back to Top
     </div>
-
-    <!-- Footer -->
 
     <div class="footer">
         <div class="footer-column">

--- a/style.css
+++ b/style.css
@@ -664,3 +664,50 @@ body {
   margin-top: 5px;
   color: red;
 }
+
+.personalised-recommendations {
+    text-align: center;
+    padding: 8px 100px;
+    background-color: white;
+    margin: 20px 0;
+}
+
+.personalised-recommendations h2 {
+    font-size: 24px;
+    margin: 40px 0 8px 0;
+    color: #0F1111;
+}
+
+.personalised-recommendations hr {
+    margin: 0 -100px;
+    border: none;
+    border-top: 1px solid #DDD;
+}
+
+.personalised-recommendations p {
+    font-size: 11px;
+    margin: 4px 0 25px 0;
+}
+
+.sign-in-button {
+    background-color: #ffd700;
+    border: none;
+    padding: 8px 100px;
+    border-radius: 50px;
+    cursor: pointer;
+    font-size: 12px;
+    margin: 2px 0;
+}
+
+.sign-in-button:hover {
+    background-color: #ffcc00;
+}
+
+.start-here-link {
+    color: #0066c0;
+}
+
+.start-here-link:hover {
+    text-decoration: underline;
+    color: #c45500;
+}


### PR DESCRIPTION
## Issue resolved:
This pr resolves issue #62 

## Description:
The issue stated that the original Amazon site has such a block, which encourages users to sign in to get more relevant recommendations, and the addition of this could improve user experience, allow for another way of navigating to sign in page as well as increase number of sign ins.

## Changes made:
- Added the proposed block at the bottom of the page
- Changed the colors to match that of the original website
- Added correct hyperlinks for navigation

## Attachments:
https://github.com/user-attachments/assets/db67bc91-765e-4f1e-86c8-da45e84ad0ed