### PR TITLE
Added privacy notice page and correctly linked it to the auth pages

### DIFF
--- a/Loginpage.html
+++ b/Loginpage.html
@@ -25,7 +25,7 @@
                 <button type="submit" class="continue-btn">Continue</button>
 
                 <p class="disclaimer">
-                    By continuing, you agree to Amazon's <a href="#">Conditions of Use</a> and <a href="#">Privacy Notice</a>.
+                    By continuing, you agree to Amazon's <a href="#">Conditions of Use</a> and <a href="privacy-notice.html">Privacy Notice</a>.
                 </p>
                 
                 <div class="help-section">
@@ -45,7 +45,7 @@
 
         <footer>
             <a href="#">Conditions of Use</a>
-            <a href="#">Privacy Notice</a>
+            <a href="privacy-notice.html">Privacy Notice</a>
             <a href="#">Help</a>
             <p>© 1996-2025, Amazon.com, Inc. or its affiliates</p>
         </footer>

--- a/Signuppage.html
+++ b/Signuppage.html
@@ -26,7 +26,7 @@
                 <button type="submit" class="continue-btn">Verify Mobile Number</button>
 
                 <p class="disclaimer">
-                    By creating an account, you agree to Amazon's <a href="#">Conditions of Use</a> and <a href="#">Privacy Notice</a>.
+                    By creating an account, you agree to Amazon's <a href="#">Conditions of Use</a> and <a href="privacy-notice.html">Privacy Notice</a>.
                 </p>
             </form>
 
@@ -38,7 +38,7 @@
 
         <footer>
             <a href="#">Conditions of Use</a>
-            <a href="#">Privacy Notice</a>
+            <a href="privacy-notice.html">Privacy Notice</a>
             <a href="#">Help</a>
             <p>© 1996-2025, Amazon.com, Inc. or its affiliates</p>
         </footer>

--- a/privacy-notice.css
+++ b/privacy-notice.css
@@ -1,0 +1,161 @@
+body {
+    margin: 0;
+    padding: 0;
+    font-family: Arial, sans-serif;
+    line-height: 1.6;
+    color: #111;
+    background-color: #f3f3f3;
+}
+
+.container {
+    max-width: 1000px;
+    margin: 20px auto;
+    padding: 20px;
+    background-color: #fff;
+    border-radius: 4px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.breadcrumb {
+    color: #555;
+    font-size: 14px;
+    margin-bottom: 20px;
+}
+
+h1 {
+    color: #111;
+    font-size: 28px;
+    margin-bottom: 20px;
+}
+
+.disclaimer {
+    background-color: #f8f8f8;
+    padding: 15px;
+    margin: 20px 0;
+    border-radius: 4px;
+}
+
+.last-updated {
+    color: #555;
+    margin-bottom: 30px;
+}
+
+.last-updated a {
+    color: #0066c0;
+    text-decoration: none;
+}
+
+.section {
+    margin-bottom: 30px;
+}
+
+.privacy-nav {
+    list-style: none;
+    padding: 0;
+}
+
+.privacy-nav li {
+    margin-bottom: 10px;
+}
+
+.privacy-nav a {
+    color: #0066c0;
+    text-decoration: none;
+}
+
+.privacy-nav a:hover {
+    text-decoration: underline;
+    color: #c45500;
+}
+
+.officer-details {
+    background-color: #f8f8f8;
+    padding: 20px;
+    border-radius: 4px;
+    margin-top: 15px;
+}
+
+footer {
+    background-color: #131921;
+    color: white;
+    padding: 20px;
+    text-align: center;
+    margin-top: 50px;
+}
+
+.footer-links {
+    margin-bottom: 10px;
+}
+
+.footer-links a {
+    color: white;
+    text-decoration: none;
+    margin: 0 10px;
+}
+
+.footer-links a:hover {
+    text-decoration: underline;
+}
+
+/* Add styles for the new content sections */
+
+.section h3 {
+    color: #333;
+    font-size: 18px;
+    margin: 20px 0 10px;
+}
+
+.purpose-list, .info-list, .info-supply-list {
+    list-style-type: none;
+    padding: 0;
+}
+
+.purpose-list li, .info-list li, .info-supply-list li {
+    margin-bottom: 15px;
+    padding-left: 20px;
+    position: relative;
+}
+
+.purpose-list li:before, .info-list li:before, .info-supply-list li:before {
+    content: "•";
+    position: absolute;
+    left: 0;
+    color: #0066c0;
+}
+
+.section ul {
+    margin-bottom: 20px;
+}
+
+.section p {
+    margin-bottom: 15px;
+    line-height: 1.6;
+}
+
+/* Add styles for example sections */
+#examples h3 {
+    color: #333;
+    font-size: 18px;
+    margin: 25px 0 15px;
+    padding-bottom: 5px;
+    border-bottom: 1px solid #eee;
+}
+
+/* Content block styling */
+.content-block {
+    background-color: #f8f8f8;
+    padding: 15px;
+    margin: 15px 0;
+    border-radius: 4px;
+}
+
+/* Link styling within content */
+.section a:not(.back-to-top) {
+    color: #0066c0;
+    text-decoration: none;
+}
+
+.section a:not(.back-to-top):hover {
+    text-decoration: underline;
+    color: #c45500;
+}

--- a/privacy-notice.html
+++ b/privacy-notice.html
@@ -1,0 +1,292 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Privacy Notice - Amazon.in</title>
+    <!-- Include Font Awesome -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <!-- Include main styles first -->
+    <link rel="stylesheet" href="style.css">
+    <!-- Then privacy notice specific styles -->
+    <link rel="stylesheet" href="privacy-notice.css">
+    <style>
+        html {
+            scroll-behavior: smooth;
+            scroll-padding-top: 20px;
+        }
+    </style>
+</head>
+<body>
+    <div id="navbar">
+        <!-- Make the amazon logo clickable which will bring the user to index.html -->
+        <a href="/index.html">
+            <img class="amazon-logo" src="./amazon assets/logo.webp">
+        </a>
+
+        <div class="location" onclick="getLocation()">
+            <span class="location-name">Deliver to Delhi 110099</span>
+            <br>
+            <span class="location-img"> <i class="fa-solid fa-location-dot"></i> </span>
+            <span class="update-location">Update Location</span>
+        </div>
+
+        <div class="search-bar">
+
+            <select name="type" class="select-type">
+                <option class="all" style="border: 4px solid #000;">All</option>
+                <option value="clothes">Alexa</option>
+                <option class="scroll">Amazon Devices</option>
+                <option value="">Amazon Fashion</option>
+                <option value="">Amazon Fresh</option>
+                <option value="">Appliances</option>
+                <option value="">Apps and Games</option>
+                <option value="">Baby</option>
+                <option value="">Beauty</option>
+                <option value="">Books</option>
+                <option value="">Car and Motorbike</option>
+                <option value="">Clothing and Accessories</option>
+                <option value="">Deals</option>
+                <option value="">Electronics</option>
+                <option value="">Furniture</option>
+            </select>
+
+            <input type="text" placeholder="Search Amazon.in" class="input-search">
+
+            <span class="search-icon">
+                <i class="fa-solid fa-magnifying-glass"></i>
+            </span>
+        </div>
+
+        <div class="dropdown">
+            <div class="dropdown-button">
+                <img src="https://flagcdn.com/w20/us.png" alt="English Flag"><p>EN</p>
+                <i class="fa-solid fa-caret-down" style="margin-left: auto; color:#fff; size:10px,16px" ></i>
+            </div>
+            <div class="dropdown-content">
+            <a href="#" data lang="en"><img src="https://flagcdn.com/w20/us.png" alt="English Flag"> EN</a>
+            <a href="#" data lang="hin"><img src="https://flagcdn.com/w20/in.png" alt="India flag">HIN</a>
+            <a href="#" data lang="es"><img src="https://flagcdn.com/w20/es.png" alt="Spain flag">ES</a>
+            <a href="#" data lang="de"><img src="https://flagcdn.com/w20/de.png" alt="German flag">DE</a>
+            <a href="#" data lang="fr"><img src="https://flagcdn.com/w20/fr.png" alt="French flag">FR</a>
+            <a href="#" data lang="it"><img src="https://flagcdn.com/w20/it.png" alt="Italian flag">IT</a>
+            </div>
+        </div>  
+       
+        <div class="sign-in">
+    <span class="sign-head">Hello, Sign In</span>
+    <div id="bottom">
+        <span class="sign-bottom">Account & Lists</span>
+        <i class="fa-solid fa-caret-down" style="color: #fff;"></i>
+    </div>
+    <div class="dropdown-menu">
+        <a href="Loginpage.html" class="dropdown-item">Sign In</a>
+        <a href="Signuppage.html" class="dropdown-item">New Customer? Sign Up</a>
+    </div>
+</div>
+
+        <div class="account">
+            <span class="location-name">Returns</span>
+            <br>
+            <span class="update-location">& Orders</span>
+        </div>
+
+        <div class="cart">
+            <i class="fa-solid fa-cart-shopping"></i>
+        </div>
+
+    </div>
+
+    <div class="lower-header">
+        <span class="lower-header-text">
+            <a href="/index.html">Home</a>
+        </span>
+        <span class="lower-header-text">Shop</span>
+        <span class="lower-header-text">Deals</span>
+        <span class="lower-header-text">New</span>
+        <span class="lower-header-text">Gift</span>
+        <span class="lower-header-text">Cart</span>
+        <span class="lower-header-text">Order</span>
+        <a href="help.html" class="lower-header-text">Help</a>
+        <span class="lower-header-text">Books</span>
+        <span class="lower-header-text">Music</span>
+        <span class="lower-header-text">Games</span>
+
+        <span class="lower-header-text">Prime</span>
+        <a href="kids.html" class="lower-header-text">Kids</a>
+
+        <a href="prime.html">
+            <span class="lower-header-text">Prime</span>
+        </a>
+        <span class="lower-header-text">Kids</span>
+
+        <a href="contact.html" class="lower-header-text">Contact Us</a>
+        <span class="lower-header-text">More</span>
+    </div>
+    <!-- Privacy Notice Content -->
+    <div class="container">
+        <div class="breadcrumb">
+            Security and Privacy › Legal Policies ›
+        </div>
+        
+        <h1>Amazon.in Privacy Notice</h1>
+        
+        <div class="disclaimer">
+            Disclaimer: In the event of any discrepancy or conflict, the English version will prevail over the translation.
+        </div>
+        
+        <div class="last-updated">
+            Last updated: April 25, 2024. <a href="#">To see prior version, click here</a>
+        </div>
+
+        <div class="main-content">
+            <!-- Main content sections -->
+            <div class="section" id="intro">
+                <p>We know that you care how information about you is used and shared, and we appreciate your trust that we will do so carefully and sensibly. This Privacy Notice describes how Amazon Seller Services Private Limited and its affiliates including Amazon.com, Inc. (collectively "Amazon") collect and process your personal information through Amazon websites, devices, products, services, online marketplace and applications that reference this Privacy Notice (together "Amazon Services").</p>
+            </div>
+
+            <div class="section">
+                <h2>Contents</h2>
+                <ul class="privacy-nav">
+                    <li><a href="#collect">What Personal Information About Customers Does Amazon Collect?</a></li>
+                    <li><a href="#purposes">For What Purposes Does Amazon Use Your Personal Information?</a></li>
+                    <li><a href="#cookies">What About Cookies and Other Identifiers?</a></li>
+                    <li><a href="#share">Does Amazon Share Your Personal Information?</a></li>
+                    <li><a href="#secure">How Secure is Information About Me?</a></li>
+                    <li><a href="#advertising">What About Advertising?</a></li>
+                    <li><a href="#access">What Information can I Access?</a></li>
+                    <li><a href="#choices">What Choices Do I Have?</a></li>
+                    <li><a href="#children">Are Children Allowed to Use Amazon Services?</a></li>
+                    <li><a href="#conditions">Conditions of Use, Notices, and Revisions</a></li>
+                </ul>
+            </div>
+
+            <div class="section" id="collect">
+                <h2>What Personal Information About Customers Does Amazon Collect?</h2>
+                <p>We collect your personal information in order to provide and continually improve our products and services.</p>
+                <h3>Types of Information We Collect:</h3>
+                <ul>
+                    <li><strong>Information You Give Us:</strong> We receive and store any information you provide in relation to Amazon Services. Click here to see examples of what we collect. You can choose not to provide certain information, but then you might not be able to take advantage of many of our Amazon Services.</li>
+                    <li><strong>Automatic Information:</strong> We automatically collect and store certain types of information about your use of Amazon Services, including information about your interaction with content and services available through Amazon Services. Like many websites, we use cookies and other unique identifiers, and we obtain certain types of information when your web browser or device accesses Amazon Services and other content served by or on behalf of Amazon on other websites. Click here to see examples of what we collect.</li>
+                    <li><strong>Information from Other Sources:</strong> We might receive information about you from other sources, such as updated delivery and address information from our carriers, which we use to correct our records and deliver your next purchase more easily. Click here to see additional examples of the information we receive.</li>
+                </ul>
+                <a href="#top" class="back-to-top">Back to Top</a>
+            </div>
+
+            <div class="section" id="purposes">
+                <h2>For What Purposes Does Amazon Use Your Personal Information?</h2>
+                <p>We use your personal information to operate, provide, develop, and improve the products and services that we offer our customers. These purposes include:</p>
+                <ul class="purpose-list">
+                    <li><strong>Purchase and delivery of products and services.</strong> We use your personal information to take and fulfill orders, deliver products and services, process payments, and communicate with you about orders, products and services, and promotional offers.</li>
+                    <li><strong>Provide, troubleshoot, and improve Amazon Services.</strong> We use your personal information to provide functionality, analyze performance, fix errors, and improve the usability and effectiveness of the Amazon Services.</li>
+                    <li><strong>Recommendations and personalization.</strong> We use your personal information to recommend features, products, and services that might be of interest to you, identify your preferences, and personalize your experience with Amazon Services.</li>
+                    <li><strong>Provide voice, image and camera services.</strong> When you use our voice, image and camera services, we use your voice input, images, videos, and other personal information to respond to your requests, provide the requested service to you, and improve our services. For more information about Alexa voice services, click here.</li>
+                    <li><strong>Comply with legal obligations.</strong> In certain cases, we collect and use your personal information to comply with laws. For instance, we collect from sellers information regarding place of establishment and bank account information for identity verification and other purposes.</li>
+                    <li><strong>Communicate with you.</strong> We use your personal information to communicate with you in relation to Amazon Services via different channels (e.g., by phone, e-mail, chat).</li>
+                    <li><strong>Advertising.</strong> We use your personal information to display interest-based ads for features, products, and services that might be of interest to you. We do not use information that personally identifies you to display interest-based ads. To learn more, please read our Interest-Based Ads notice.</li>
+                    <li><strong>Fraud Prevention and Credit Risks.</strong> We use personal information to prevent and detect fraud and abuse in order to protect the security of our customers, Amazon, and others. We may also use scoring methods to assess and manage credit risks.</li>
+                </ul>
+                <a href="#top" class="back-to-top">Back to Top</a>
+            </div>
+
+            <div class="section" id="cookies">
+                <h2>What About Cookies and Other Identifiers?</h2>
+                <p>To enable our systems to recognize your browser or device and to provide and improve Amazon Services, we use cookies and other identifiers. For more information about cookies and how we use them, please read our Cookies Notice.</p>
+                <a href="#top" class="back-to-top">Back to Top</a>
+            </div>
+
+            <div class="section" id="share">
+                <h2>Does Amazon Share Your Personal Information?</h2>
+                <p>Information about our customers is an important part of our business and we are not in the business of selling our customers’ personal information to others. We share customers’ personal information only as described below and with Amazon.com, Inc. and subsidiaries that Amazon.com, Inc. controls that either are subject to this Privacy Notice or follow practices at least as protective as those described in this Privacy Notice.</p>
+                <ul>
+                    <li><strong>Transactions involving Third Parties:</strong> We make available to you services, products, applications, or skills provided by third parties for use on or through Amazon Services. For example, the products you order through our marketplace are from third parties, you can download applications from third-party application providers from our App Store, and enable third-party skills through our Alexa services. We also offer services or sell product lines jointly with third-party businesses, such as sellers on the marketplace, restaurants registered on Amazon.in, merchants providing mobile recharges and bill-payment assistance. You can tell when a third party is involved in your transactions, and we share customers’ personal information related to those transactions with that third party.</li>
+                    <li><strong>Third-Party Service Providers:</strong> We employ other companies and individuals to perform functions on our behalf. Examples include fulfilling orders for products or services, delivering packages, sending postal mail and e-mail, removing repetitive information from customer lists, analyzing data, providing marketing assistance, providing search results and links (including paid listings and links), processing payments, transmitting content, scoring, assessing and managing credit risk, and providing customer service. These third-party service providers have access to personal information needed to perform their functions, but may not use it for other purposes. Further, they must process the personal information in accordance with applicable law.</li>
+                    <li><strong>Business Transfers:</strong> As we continue to develop our business, we might sell or buy other businesses or services. In such transactions, customer information generally is one of the transferred business assets but remains subject to the promises made in any pre-existing Privacy Notice (unless, of course, the customer consents otherwise). Also, in the unlikely event that Amazon.com, Inc. or Amazon Seller Services Private Limited or any of its affiliates, or substantially all of their assets are acquired, customer information will of course be one of the transferred assets.</li>
+                    <li><strong>Protection of Amazon and Others:</strong> We release account and other personal information when we believe release is appropriate to comply with the law; enforce or apply our Conditions of Use and other agreements; or protect the rights, property, or safety of Amazon, our users, or others. This includes exchanging information with other companies and organizations for fraud protection and credit risk reduction.</li>
+                </ul>
+                <p>Other than as set out above, you will receive notice when personal information about you might be shared with third parties, and you will have an opportunity to choose not to share the information.</p>
+                <a href="#top" class="back-to-top">Back to Top</a>
+            </div>
+
+            <div class="section" id="secure">
+                <h2>How Secure Is Information About Me?</h2>
+                <p>We design our systems with your security and privacy in mind.</p>
+                <ul>
+                    <li>We work to protect the security of your personal information during transmission by using encryption protocols and software.</li>
+                    <li>We follow the Payment Card Industry Data Security Standard (PCI DSS) when handling payment card data.</li>
+                    <li>We maintain physical, electronic, and procedural safeguards in connection with the collection, storage, processing, and disclosure of personal customer information. Our security procedures mean that we may occasionally request proof of identity before we disclose personal information to you.</li>
+                    <li>Our devices offer security features to protect them against unauthorized access and loss of data. You can control these features and configure them based on your needs. Click here for more information on how to manage the security settings of your device.</li>
+                </ul>
+                <p>It is important for you to protect against unauthorized access to your password and to your computers, devices and applications. Be sure to sign off when finished using a shared computer. Click here for more information on how to sign off.</p>
+                <a href="#top" class="back-to-top">Back to Top</a>
+            </div>
+
+            <div class="section" id="advertising">
+                <h2>What About Advertising?</h2>
+                <p><strong>Third-Party Advertisers and Links to Other Websites:</strong> Amazon Services may include third-party advertising and links to other websites and apps. Third-party advertising partners may collect information about you when you interact with their content, advertising, and services. For more information about third-party advertising at Amazon, including interest-based ads, please read our Interest-Based Ads policy. To adjust your advertising preferences, please go to the Advertising Preferences page.</p>
+                <p><strong>Use of Third-Party Advertising Services:</strong> We provide ad companies with information that allows them to serve you with more useful and relevant Amazon ads and to measure their effectiveness. We never share your name or other information that directly identifies you when we do this. Instead, we use an advertising identifier like a cookie, a device identifier, or a code derived from applying irreversible cryptography to other information like an email address. For example, if you have already downloaded one of our apps, we will share your advertising identifier and data about that event so that you will not be served an ad to download the app again. Some ad companies also use this information to serve you relevant ads from other advertisers. You can learn more about how to opt-out of interest-based advertising by going to the Advertising Preferences page.</p>
+                <a href="#top" class="back-to-top">Back to Top</a>
+            </div>
+
+            <div class="section" id="access">
+                <h2>What Information Can I Access?</h2>
+                <p>You can access your information, including your name, address, payment options, profile information, Prime membership, household settings, and purchase history in the "Your Account" section of the website or mobile application. Click here for a list of examples that you can access. To request access to personal information that is not available through Your Account you can submit a request here.</p>
+                <a href="#top" class="back-to-top">Back to Top</a>
+            </div>
+
+            <div class="section" id="choices">
+                <h2>What Choices Do I Have?</h2>
+                <p>If you have any questions as to how we collect and use your personal information, please contact our Grievance Officer. Many of our Amazon Services also include settings that provide you with options as to how your information is being used.</p>
+                <p>As described above, you can always choose not to provide certain information, but then you might not be able to take advantage of many of the Amazon Services.</p>
+                <p>You can add or update certain information on pages such as those referenced in What Information Can I Access?. When you update information, we usually keep a copy of the prior version for our records.</p>
+                <p>If you do not want to receive e-mail or other communications from us, please adjust your Customer Communication Preferences. If you don’t want to receive in-app notifications from us, please adjust your notification settings in the app or device.</p>
+                <p>If you do not want to see interest-based ads, please adjust your Advertising Preferences.</p>
+                <p>The Help feature on most browsers and devices will tell you how to prevent your browser or device from accepting new cookies or other identifiers, how to have the browser notify you when you receive a new cookie or how to block cookies altogether. Because cookies and identifiers allow you to take advantage of some essential features of Amazon Services, we recommend that you leave them turned on. For instance, if you block or otherwise reject our cookies, you will not be able to add items to your Shopping Cart, proceed to Checkout, or use any Services that require you to Sign in. For more information about cookies and other identifiers, see our Cookies Notice.</p>
+                <p>If you want to browse our websites without linking the browsing history to your account, you may do so by logging out of your account here and blocking cookies on your browser.</p>
+                <p>You will also be able to opt out of certain other types of data usage by updating your settings on the applicable Amazon website (e.g., in "Manage Your Content and Devices"), device, or application. For more information click here. Most non-Amazon devices also provide users with the ability to change device permissions (e.g., disable/access location services, contacts). For most devices, these controls are located in the device's settings menu. If you have questions about how to change your device permissions on devices manufactured by third parties, we recommend you contact your mobile service carrier or your device manufacturer.</p>
+                <p>If you are a seller, you can add or update certain information in Seller Central, update your account information by accessing your Seller Account Information, and adjust your e-mail or other communications you receive from us by updating your Notification Preferences.</p>
+                <a href="#top" class="back-to-top">Back to Top</a>
+            </div>
+
+            <div class="section" id="children">
+                <h2>Are Children Allowed to Use Amazon Services?</h2>
+                <p>Amazon does not sell products for purchase by children. We sell children's products for purchase by adults. If you are under the age of 18 years, you may use Amazon Services only with the involvement of a parent or guardian.</p>
+                <a href="#top" class="back-to-top">Back to Top</a>
+            </div>
+
+            <div class="section" id="conditions">
+                <h2>Conditions of Use, Notices, and Revisions</h2>
+                <p>If you choose to use Amazon Services, your use and any dispute over privacy is subject to this Notice and our Conditions of Use, including limitations on damages, resolution of disputes, and application of the prevailing law in India. If you have any concern about privacy at Amazon, please contact us with a thorough description, and we will try to resolve it. Our business changes constantly, and our Privacy Notice will change also. You should check our websites frequently to see recent changes.</p>
+                <p>Unless stated otherwise, our current Privacy Notice applies to all information that we have about you and your account. We stand behind the promises we make, however, and will never materially change our policies and practices to make them less protective of customer information collected in the past without the consent of affected customers.</p>
+                <a href="#top" class="back-to-top">Back to Top</a>
+            </div>
+
+            <div class="section" id="grievance">
+                <h2>Grievance Officer</h2>
+                <p>Please find below the details of the grievance officer:</p>
+                <div class="officer-details">
+                    <p><strong>Name:</strong> Saurabh Joshi</p>
+                    <p><strong>Designation:</strong> Grievance officer</p>
+                    <p><strong>Email:</strong> grievance-officer@amazon.in</p>
+                    <p><strong>Fax:</strong> 040 – 39922887</p>
+                    <p><strong>Address:</strong> Amazon Seller Services Private Limited (9O), Nos. 1401 to 1421, 14th Floor Block - E, International Trade Tower, Nehru Place New Delhi, Delhi 110019</p>
+                </div>
+                <a href="#top" class="back-to-top">Back to Top</a>
+            </div>
+        </div>
+
+        <div class="return-home">
+            <a href="index.html" class="return-home-btn">Return to Home Page</a>
+        </div>
+    </div>
+
+    <footer>
+        <div class="footer-links">
+            <a href="#">Conditions of Use</a>
+            <a href="#">Help</a>
+            <a href="#">Privacy Notice</a>
+        </div>
+        <p>© 1996-2025, Amazon.com, Inc. or its affiliates</p>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
## Description:
The issue stated that in the auth forms (sign up and login pages), in the subtext there is a hyperlink for Privacy Notice. On the original Amazon website, this takes the users to a dedicated page for the Privacy Notice. I would like to add a similar implementation to this clone project. The proposed changes were to make a dedicated page for the Privacy Notice and link it to the hyperlink in the subtext of the auth forms.

## Changes made:
- Created a Privacy Notice page to the website
- Styled the page according to the rest of the website
- Made the questions on the page clickable so the page scrolls down to the answer on click
- Linked this Privacy Notice page to the auth forms

## Attachments:

https://github.com/user-attachments/assets/8443c0e3-e1b0-42b8-8fb4-26dc0d8d14c9

Thank you!