### PR TITLE
Fixed invalid name input validation on Contact Us page #78

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -108,7 +108,7 @@
 
         <form class="contact-form" onsubmit="handleSubmit(event)">
             <label for="name">Your Name</label>
-            <input type="text" id="name" name="name" placeholder="Enter your name" required>
+            <input type="text" id="name" pattern = "[a-z A-Z]{2,20}" name="name" placeholder="Enter your name" required>
 
             <label for="email">Your Email</label>
             <input type="email" id="email" name="email" placeholder="Enter your email" required>


### PR DESCRIPTION
Firstly, the name input in the Contact Us page was accepting text, numbers and special symbols as input which is incorrect format.

Fixed the name input in the Contact Us page now it is accepting only text of a certain length, if somebody enters numbers or special symbols, a pop up appears "Please match the requested format".

Providing video:
Before fixing the bug:

https://github.com/user-attachments/assets/08305f55-ef71-4052-8393-6221533821b3

After fixing the bug:

https://github.com/user-attachments/assets/f5b70927-2a35-410f-bcf0-351beb6ba1e2

